### PR TITLE
Add socks Support to Resolve ImportError

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -13,7 +13,7 @@ websockets = "^12.0"
 openai = "^1.2.4"
 python-dotenv = "^1.0.0"
 beautifulsoup4 = "^4.12.2"
-httpx = "^0.25.1"
+httpx = {extras = ["socks"], version = "^0.25.1"}
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
This PR aims to address the `ImportError` encountered in the project. During the API requests, the following error was observed:


To fix this issue, I have changed the dependency configuration of `httpx` from `httpx = "^0.25.1"` to `httpx = {extras = ["socks"], version = "^0.25.1"}`. This change ensures that the `socks` extra dependency is included when installing `httpx`, thereby enabling SOCKS proxy support.

After making this change, the API request issue was resolved, and the project is functioning normally again.
